### PR TITLE
Adding logging

### DIFF
--- a/numcmctools/__init__.py
+++ b/numcmctools/__init__.py
@@ -1,5 +1,11 @@
+import logging
 from numcmctools.mcmcsamples import MCMCSamples
 from numcmctools.variable import Variable
 from numcmctools.plotstack import PlotStack
 from numcmctools.plot import Plot 
 from numcmctools.jacobiangraph import JacobianGraph
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s::%(levelname)s::%(name)s: - %(message)s')
+
+def set_logging_level(level):
+    logging.getLogger().setLevel(level)

--- a/numcmctools/jacobiangraph.py
+++ b/numcmctools/jacobiangraph.py
@@ -1,7 +1,10 @@
 import sympy as sp
 import re
+import logging
 from typing import Callable, Optional, Dict, Tuple, List
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 class JacobianGraph:
 
@@ -59,14 +62,14 @@ class JacobianGraph:
             jacobian = sp.Abs(dtarget_dx / dsource_dx)
 
             if jacobian == 0:
-                print(f"Jacobian transformation from {source} to {target} not possible, got 0")
+                logger.debug(f"Jacobian transformation from {source} to {target} not possible, got 0")
                 return None
 
             # Return numpified Jacobian transform function
             return sp.lambdify(self.x, target, modules=['numpy']), sp.lambdify(self.x, jacobian, modules=['numpy'])
 
         except Exception as e:
-            print(f"Jacobian transformation from {source} to {target} error: {e}")
+            logger.error(f"Jacobian transformation from {source} to {target} error: {e}")
             return None
 
     def __build_graphs(self):
@@ -190,7 +193,7 @@ class JacobianGraph:
 
         # Error checking
         if from_dist_type != 'Uniform':
-            print(f"Warning: Transforming from a gaussian distribution not supported, here be dragons!")
+            logger.debug(f"Transforming from a gaussian distribution not supported, here be dragons!")
         if from_expr not in self.jacobian_graph or to_expr not in self.jacobian_graph[from_expr]:
             raise ValueError(f"No direct transformation available for {from_prior} to {to_prior}")
 

--- a/numcmctools/mcmcsamples.py
+++ b/numcmctools/mcmcsamples.py
@@ -1,8 +1,11 @@
 import uproot
 import numpy as np
+import logging, sys
 from typing import Callable, Dict
 from .variable import Variable
 from .jacobiangraph import JacobianGraph
+
+logger = logging.getLogger(__name__)
 
 class MCMCSamples:
     compulsory_variables = [
@@ -14,7 +17,7 @@ class MCMCSamples:
             "Deltam2_21",
             ]
 
-    def __init__(self, _filepath, _treename, _branches=[]):
+    def __init__(self, _filepath, _treename,_branches=[]):
         """
         Initialise the MCMCSamples object.
 
@@ -36,7 +39,8 @@ class MCMCSamples:
         # Get self.priors
         self.__check_and_extract_priors()
 
-        print(f"Successfully initialised MCMCSamples object with ROOT file '{self.filepath}' and '{self.treename}' TTree inside")
+        logger.info(f"Successfully initialised MCMCSamples object with ROOT file '{self.filepath}' and '{self.treename}' TTree inside")
+
 
     def __check_and_extract_variables(self):
         """
@@ -49,6 +53,7 @@ class MCMCSamples:
             if var in keys:
                 # Create new variable
                 self.variables[var] = Variable(var, lambda **kwargs: kwargs[var])
+                logger.debug(f"Compulsory variable {var} found in the root file")
             else:
                 raise ValueError(f"Compulsory variable '{var}' not found in the TTree.")
 
@@ -110,6 +115,7 @@ class MCMCSamples:
             prior = p.member('fTitle')
             if name in self.variables:
                 priors.append(prior)
+                logger.debug(f"Prior for {name} found, with format: {prior}")
             else:
                 # Don't try to fill prior for variable that does not exist!
                 raise ValueError("Prior defined for {name}, but variable {name} does not exist!")

--- a/numcmctools/plot.py
+++ b/numcmctools/plot.py
@@ -1,6 +1,9 @@
 import numpy as np
 import matplotlib.pyplot as plt
+import logging
 from .jacobiangraph import JacobianGraph
+
+logger = logging.getLogger(__name__)
 
 class Plot:
     def __init__(self, variables, jacobians, bins, axrange=None, mo_option=False):
@@ -42,7 +45,7 @@ class Plot:
                 self.hist_no = np.zeros(np.shape(self.hist))
                 self.hist_io = np.zeros(np.shape(self.hist))
         else:
-            print("too many or too few variables!")
+            logger.error("too many or too few variables!")
             return
                 
     def fill_plot(self, data, weights=None):
@@ -85,7 +88,7 @@ class Plot:
                     hist, edgesx, edgesy = np.histogram2d(data[self.variables[0]], data[self.variables[1]], self.bins, self.axrange, weights = weights)
                     self.hist += hist
         else:
-            print("histogram was finalized already! No filling allowed!")
+            logger.warn("histogram was finalized already! No filling allowed!")
 
     def finalize_histogram(self):
         """

--- a/numcmctools/plotstack.py
+++ b/numcmctools/plotstack.py
@@ -3,7 +3,10 @@ from .mcmcsamples import MCMCSamples
 from .jacobiangraph import JacobianGraph
 import numpy as np
 from tqdm import tqdm
+import logging
 import matplotlib.pyplot as plt
+
+logger = logging.getLogger(__name__)
 
 class PlotStack:
     def __init__(self, chain: MCMCSamples):
@@ -41,17 +44,17 @@ class PlotStack:
         # TODO: Would be nice to have some "verbose" option.
         plot_jacobians = {}
         if not priors:
-            print(f"No priors supplied for plot with variables: {variables}, will be uniform in whatever the supplied chain is in.")
+            logger.debug(f"No priors supplied for plot with variables: {variables}, will be uniform in whatever the supplied chain is in.")
             for var in self.chain.compulsory_variables:
                 plot_jacobians[var] = None
         else:
             parsed_priors = self.jacobian_graph.parse_priors(priors, self.chain.compulsory_variables)
             for var in self.chain.compulsory_variables:
                 if var not in parsed_priors:
-                    print(f"No prior for variable {var} supplied in plot: {variables}, will be uniform in whatever the supplied chain is in.")
+                    logger.debug(f"No prior for variable {var} supplied in plot: {variables}, will be uniform in whatever the supplied chain is in.")
                     plot_jacobians[var] = None
                 else:
-                    print(f"Prior for variable {var} supplied in plot: {variables}: {parsed_priors[var]}")
+                    logger.debug(f"Prior for variable {var} supplied in plot: {variables}: {parsed_priors[var]}")
                     plot_jacobians[var] = self.jacobian_graph.get_jacobian_func(self.chain.variable_priors[var], parsed_priors[var])
 
         # Crash if user supplied a non-existant variable


### PR DESCRIPTION
Less verbose logging, with default logging level set to `INFO`.
User can change the verbosity by adding the following lines to their macro e.g.:
```
import logging
import numcmctools

numcmctools.set_logging_level(logging.DEBUG)

# The rest of the code, e.g. samples = numcmctools.MCMCSamples("filename.root", "mcmc_samples")
```