### PR TITLE
Asztuc/drawing inputs

### DIFF
--- a/examples/plot_triangle.py
+++ b/examples/plot_triangle.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+import os
+import numpy as np
+import matplotlib.pyplot as plt
+
+from numcmctools import PlotStack, MCMCSamples
+
+# Define custom variable: ssth23
+def ssth23(Theta23) ->np.ndarray:
+    return  np.power(np.sin(Theta23), 2)
+
+# Define custom variable: ss2th13
+def ss2th13(Theta13) ->np.ndarray:
+    return np.power(np.sin(2*Theta13), 2)
+
+# Define custom variable: ss2th12
+def ss2th12(Theta12) ->np.ndarray:
+    return np.power(np.sin(2*Theta12), 2)
+
+# Define custom variable: abs(dm32) (scaled)
+def absdm32(Deltam2_32) ->np.ndarray:
+    return np.abs(Deltam2_32 * 1e3)
+
+# Define custom variable: abs(dm21) (scaled)
+def scaleddm21(Deltam2_21) ->np.ndarray:
+    return np.abs(Deltam2_21 * 1e5)
+
+def main(file: str, chain_name: str):
+  # Create the MCMCSamples object
+  samples = MCMCSamples(file, chain_name)
+
+  variable_names = ["DeltaCP_02pi", "SinSq2Theta13", "SinSqTheta23", "SinSq2Theta12", "AbsDm32", "Dm21"]
+  labels = [r"$\delta_{CP}$", r"$\sin^{2}(2\theta_{13})$", r"$\sin^{2}(\theta_{23})$", r"$\sin^{2}(2\theta_{12})$", r"$|\Delta m^{2}_{32}|$ ($\times10^{-3}$eV)", r"$|\Delta m^{2}_{21}|$ ($\times10^{-5}$eV)"]
+  bins = [50, 50, 50, 50, 50, 50]
+  ranges = [[0, 2*np.pi], [0.03, 0.16], [0.35, 0.65], [0.78, 0.91], [2.15, 2.65], [6, 9]]
+
+  priors = ["Uniform:DeltaCP",
+            "Gaussian(0.085,0.003):sin^2(2Theta13)",
+            "Uniform:sin^2(2Theta12)",
+            "Uniform:sin^2(Theta23)"]
+
+  # Add the new variables to the MCMCSamples object
+  samples.add_variable("SinSqTheta23", ssth23)
+  samples.add_variable("SinSq2Theta13", ss2th13)
+  samples.add_variable("SinSq2Theta12", ss2th12)
+  samples.add_variable("AbsDm32", absdm32)
+  samples.add_variable("Dm21", scaleddm21)
+
+  # Add all the 1D and 2D plots we want into the stack
+  stack = PlotStack(samples)
+  for i, pl_i in enumerate(variable_names):
+    for j, pl_j in enumerate(variable_names):
+      if i < j:
+        continue
+      if i == j:
+        stack.add_plot([variable_names[i]], priors, bins[i], ranges[i], True)
+      else:
+        stack.add_plot([variable_names[j], variable_names[i]], priors, [bins[j], bins[i]], [ranges[j], ranges[i]], True)
+
+  # Fill the plots
+  stack.fill_plots(batchsize=1000000)
+
+  # Plot with pyplot
+  n = len(variable_names)
+  fig = plt.figure()
+
+  # Create the NxN plot grid for the triangle plot
+  gs = fig.add_gridspec(n, n, hspace=0, wspace=0)
+  axes = gs.subplots(sharex='col')
+
+  enum = 0
+  for i, pl_i in enumerate(variable_names):
+    for j, pl_j in enumerate(variable_names):
+      # Don't show anything for the upper triangle half
+      if i < j:
+        axes[i, j].set_axis_off()
+        continue
+      
+      # Get the axis and stack plot for easier use later
+      ax = axes[i,j]
+      plot = stack.plots[enum]
+
+      # Make the 1 and 2 sigma credible intervals
+      plot.make_intervals([0.6827,0.9545])
+      plot.draw_interval(ax)
+
+      # Set the labels for all the 1D and 2D plots
+      if i == j:
+           ax.set_xlabel(labels[i])
+           ax.set_ylabel("Posterior probability")
+      else:
+           ax.set_xlabel(labels[j])
+           ax.set_ylabel(labels[i])
+
+      # Force the dcp axis to stay within 0--2pi
+      if i == 0:
+          ax.set_xlim(0, 2*np.pi)
+
+      # Ticks stylistics
+      ax.tick_params(bottom=True, top=True, left=True, right=True, direction='in')
+      ax.minorticks_on()
+      ax.tick_params(which='minor', bottom=True, top=True, left=True, right=True, direction='in')
+      enum += 1
+
+  # Only show lables for the outer plots
+  for ax in fig.get_axes():
+    ax.label_outer()
+  
+  # Save the plot
+  fig.set_size_inches(10, 10)
+  plt.savefig("triangle_noio.png", dpi=300)
+
+if __name__ == "__main__":
+  import argparse
+  
+  parser = argparse.ArgumentParser()
+
+  parser.add_argument('-f', '--file', dest="file")
+  parser.add_argument('-c', '--chain', dest="chain")
+
+  args = parser.parse_args()
+  main(str(args.file), str(args.chain))

--- a/examples/testuproot.py
+++ b/examples/testuproot.py
@@ -22,20 +22,31 @@ stack.add_plot(["DeltaCP"],[],[-np.pi, -0.95*np.pi, -0.9*np.pi, -0.85*np.pi, -0.
                                    0.2*np.pi, 0.4*np.pi, 0.6*np.pi, 0.8*np.pi, np.pi], mo_option=True)
 stack.fill_plots()
 
+# Create figure and a gridspace
 fig = plt.figure()
-axs = fig.subfigures(2, 2)
+gs = fig.add_gridspec(2, 4)
 
-stack.plots[0].draw_plot(axs[0,0])
-stack.plots[1].draw_plot(axs[1,0])
+# Make plt.Axes oobject for each subplot
+ax1 = fig.add_subplot(gs[0, :2])
+ax2 = fig.add_subplot(gs[0, 2:])
+ax3 = fig.add_subplot(gs[1, :2])
+
+# Merge y axis for the very last plot, where we want no and io next to each other
+gs_sub = gs[1, 2:].subgridspec(1, 2, wspace=0)
+ax4_no = fig.add_subplot(gs_sub[0, 0])
+ax4_io =  fig.add_subplot(gs_sub[0, 1], sharey=ax4_no) 
+plt.setp(ax4_io.get_yticklabels(), visible=False)
+
+# Draw all the plots
+stack.plots[0].draw_plot(ax1)
+stack.plots[1].draw_plot(ax3)
 
 stack.plots[0].make_intervals([0.68,0.95])
-stack.plots[0].draw_interval(axs[0,1])
+stack.plots[0].draw_interval(ax2)
 
 stack.plots[1].make_intervals([0.68,0.95])
-stack.plots[1].draw_interval(axs[1,1])
-axs_ax = axs[1,1].get_axes()
-axs_ax[0].set_xlabel(r'$\delta_{CP}$ NO')
-axs_ax[1].set_xlabel(r'$\delta_{CP}$ IO')
+stack.plots[1].draw_interval(ax3)
+stack.plots[1].draw_interval([ax4_no, ax4_io])
 
 plt.show()
 

--- a/examples/testuprootextrabranch.py
+++ b/examples/testuprootextrabranch.py
@@ -29,7 +29,8 @@ stack.fill_plots()
 
 
 fig = plt.figure()
-axs = fig.subfigures(3, 2)
+gs = fig.add_gridspec(3,2)
+axs = gs.subplots()
 
 stack.plots[0].draw_plot(axs[0,0])
 stack.plots[1].draw_plot(axs[1,0])

--- a/numcmctools/plot.py
+++ b/numcmctools/plot.py
@@ -130,12 +130,12 @@ class Plot:
         if isinstance(saxis, plt.Axes):
             if self.nvar > 1 and self.mo_option:
                 raise ValueError(f"Cannot plot 2 2D heatmaps on top of each other, need to provide 2 plt.Axes in a list")
-        elif isinstance(saxis, list) and all(isinstance(ax, plt.Axes) for ax in saxis) and self.mo_option:
+        elif isinstance(saxis, (list, np.ndarray)) and all(isinstance(ax, plt.Axes) for ax in saxis):
             if len(saxis) > 2:
                 raise ValueError(f"Maximum length of the axis list is 2, one per mass ordering of Deltam2_32")
             is_axis_array = True
         else:
-            raise ValueError(f"draw_plot: You can either provide list of plt.Axes objects with mo_option=True, or single plt.Axes object with mo_option=False!")
+            raise ValueError("Wrong instance of axes, should be either plt.Axes or List[plt.axes]!")
 
         if(self.nvar==1):
             if self.mo_option:
@@ -184,12 +184,12 @@ class Plot:
         is_axis_array = False
         if isinstance(saxis, plt.Axes):
             is_axis_array = False
-        elif isinstance(saxis, list) and all(isinstance(ax, plt.Axes) for ax in saxis) and self.mo_option:
+        elif isinstance(saxis, (list, np.ndarray)) and all(isinstance(ax, plt.Axes) for ax in saxis):
             if len(saxis) > 2:
                 raise ValueError(f"Maximum length of the axis list is 2, one per mass ordering of Deltam2_32")
             is_axis_array = True
         else:
-            raise ValueError(f"draw_interval: You can either provide list of plt.Axes objects with mo_option=True, or single plt.Axes object with mo_option=False!")
+            raise ValueError("Wrong instance of axes, should be either plt.Axes or List[plt.axes]!")
         
         #need to put in a check if the intervals have been calculated
         if(self.nvar==1):

--- a/numcmctools/plotstack.py
+++ b/numcmctools/plotstack.py
@@ -125,12 +125,19 @@ class PlotStack:
         self.figplt = plt.figure()
         self.sfigplt = self.figplt.subfigures(xplt, yplt)
 
-        for index, plot in enumerate(self.plots):
-            if(xplt> 1 and yplt>1):
-                ind = np.unravel_index(index,(xplt, yplt))
-                plot.draw_plot(self.sfigplt[ind[0],ind[1]]);
+        for index, (plot, subfig) in enumerate(zip(self.plots, self.sfigplt.flat)):
+            ax = None
+            if plot.mo_option:
+                a1, a2 = subfig.subplots(1,2, sharey='row', squeeze=True)
+                ax = [a1, a2]
+                subfig.subplots_adjust(wspace=0)
             else:
-                plot.draw_plot(self.sfigplt[index])
+                ax = subfig.add_subplot()
+
+            plot.draw_plot(ax)
+
+            for ax in subfig.get_axes():
+                ax.label_outer()
         return self.figplt, self.sfigplt
 
     def draw_intervals(self, plot_array_dim = []):
@@ -154,12 +161,19 @@ class PlotStack:
         self.figint = plt.figure()
         self.sfigint = self.figint.subfigures(xplt, yplt)
         
-        for index, plot in enumerate(self.plots):
-            if(xplt> 1 and yplt>1):
-                ind = np.unravel_index(index,(xplt, yplt))
-                plot.draw_interval(self.sfigint[ind[0],ind[1]]);
+        for index, (plot, subfig) in enumerate(zip(self.plots, self.sfigint.flat)):
+            ax = None
+            if plot.mo_option:
+                a1, a2 = subfig.subplots(1,2, sharey='row', squeeze=True)
+                ax = [a1, a2]
+                subfig.subplots_adjust(wspace=0)
             else:
-                plot.draw_interval(self.sfigint[index])
+                ax = subfig.add_subplot()
+
+            plot.draw_interval(ax)
+
+            for ax in subfig.get_axes():
+                ax.label_outer()
 
         return self.figint, self.sfigint
 

--- a/numcmctools/plotstack.py
+++ b/numcmctools/plotstack.py
@@ -129,22 +129,22 @@ class PlotStack:
 
         self.figplt = plt.figure()
         self.sfigplt = self.figplt.subfigures(xplt, yplt)
+        self.saxesplt = []
 
         for index, (plot, subfig) in enumerate(zip(self.plots, self.sfigplt.flat)):
-            #ax = None
             if plot.mo_option:
-                #a1, a2 = subfig.subplots(1,2, sharey='row', squeeze=True)
-                #ax = [a1, a2]
                 ax = subfig.subplots(1,2, sharey='row', squeeze=True)
                 subfig.subplots_adjust(wspace=0)
+                self.saxesplt.append(ax)
             else:
                 ax = subfig.add_subplot()
+                self.saxesplt.append([ax])
 
             plot.draw_plot(ax)
 
             for ax in subfig.get_axes():
                 ax.label_outer()
-        return self.figplt, self.sfigplt
+        return self.figplt, self.sfigplt, self.saxesplt
 
     def draw_intervals(self, plot_array_dim = [], mo_separate=True):
         """
@@ -166,23 +166,23 @@ class PlotStack:
 
         self.figint = plt.figure()
         self.sfigint = self.figint.subfigures(xplt, yplt)
+        self.axesint = []
         
         for index, (plot, subfig) in enumerate(zip(self.plots, self.sfigint.flat)):
             ax = None
             if plot.mo_option:
-                #a1, a2 = subfig.subplots(1,2, sharey='row', squeeze=True)
-                #ax = [a1, a2]
                 ax = subfig.subplots(1,2, sharey='row', squeeze=True)
+                self.axesint.append(ax)
                 subfig.subplots_adjust(wspace=0)
             else:
                 ax = subfig.add_subplot()
-
+                self.axesint.append([ax])
             plot.draw_interval(ax)
 
             for ax in subfig.get_axes():
                 ax.label_outer()
 
-        return self.figint, self.sfigint
+        return self.figint, self.sfigint, self.axesint
 
     def __determine_plot_array(self):
         """


### PR DESCRIPTION
List of changes:
1. `plot.draw_plot` (should it be renamed to `draw_posterior`? and `plot.draw_interval` can now take either `plt.Axes` or `List[plt.Axes]`, to draw NO/IO either on the same or separate axes.
2. `plotstack.draw_plots` (should it be renamed to draw_posteriors?) and `plotstack.draw_intervals` still create their own figures, axes etc. so the user doesn't have to.
3. New executable `draw_triangle`, takes input arguments so can be used for any posterior.

These changes were made so the user can use e.g. `gridspec` object to have fully-customizable plot grid.

The disadvantage is that, if the user wants to draw each plot individually rather than through `plotstack`, then they have to worry about creating correct grids/axes themselves. I personally think it's fine though, it allows for full customizability of the layout, and if they don't want that, then they should use plotstack for drawing anyway. 