### PR TITLE
New priors for MO bias & automatic DCP wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,15 @@ splittings. For more information on the parameterization see the [PDG
 review on neutrino mixing](https://pdg.lbl.gov/2024/web/viewer.html?file=../reviews/rpp2024-rev-neutrino-mixing.pdf).
 
 Each parameter has some prior set by the original analyzers. The
-format of this information is a TList containing a TNamed for each branch, 
-which specifies the name of the branch and its prior. 
+format of this information is a TList containing a TNamed for each branch,
+which specifies the name of the branch and its prior.
 
-The priors are specified as either `Uniform` or `Gaussian(mean, sigma)`.
+The priors are specified as:
+1. `Uniform` 
+2. `Gaussian(mean, sigma)`
+4. `BimodalGaussian(mean1, sigma1, mean2, sigma2, bias)` where bias is in % and optional, default 50%.
+3. `Step(bias, boundary)` where bias is in % and boundary is optional, default 0
+
 There is then a further specification as to which variable the functional form
 applies to. For example, a specification of
 
@@ -176,12 +181,16 @@ sin(x)
 sin^2(x)
 cos(x)
 cos^2(x)
+cos^4(x)
 2x
 sin(2x)
 sin^2(2x)
 cos(2x)
 cos^2(2x)
+cos^4(2x)
 exp(-ix)
+exp(ix)
+abs(ix)
 ```
 
 For example, an input chain that has a prior set to be uniform in DeltaCP can

--- a/examples/simpleplots.py
+++ b/examples/simpleplots.py
@@ -18,7 +18,7 @@ stack = PlotStack(samples)
 
 #define a 1D and 2D plot; note the 1D plot has both non-equal bins and is split by mass-ordering
 stack.add_plot(["Deltam2_32", "Theta23"],[],[50,50],[[2.2E-3,2.7E-3],[0.7,0.9]])
-stack.add_plot(["DeltaCP"],[],[-np.pi, -0.95*np.pi, -0.9*np.pi, -0.85*np.pi, -0.8*np.pi, -0.75*np.pi,
+stack.add_plot(["DeltaCP_pipi"],[],[-np.pi, -0.95*np.pi, -0.9*np.pi, -0.85*np.pi, -0.8*np.pi, -0.75*np.pi,
                                    -0.7*np.pi,  -0.65*np.pi,  -0.6*np.pi,  -0.55*np.pi,  -0.5*np.pi,
                                     -0.45*np.pi,  -0.4*np.pi,  -0.35*np.pi,  -0.3*np.pi,  -0.25*np.pi,
                                      -0.2*np.pi,  -0.15*np.pi,  -0.1*np.pi,  -0.05*np.pi, 0,

--- a/numcmctools/jacobiangraph.py
+++ b/numcmctools/jacobiangraph.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 class JacobianGraph:
 
     # Define symbolic variable
-    x = sp.Symbol('x')
+    x = sp.Symbol('x', real=True)
 
     # Pre-defined priors
     variables = {
@@ -26,12 +26,23 @@ class JacobianGraph:
             'cos^2(2x)': sp.cos(2*x)**2,
             'cos^4(2x)': sp.cos(2*x)**4,
             'exp(-ix)': sp.exp(-sp.I * x),
-            'exp(ix)': sp.exp(sp.I * x)
+            'exp(ix)': sp.exp(sp.I * x),
+            'abs(x)': sp.Abs(x)
             }
 
     # Possible distribution functions (not including Uniform)
     distribution_functions: Dict[str, Callable[..., Callable[[np.ndarray], np.ndarray]]] = {
-        'Gaussian': lambda mean, std: lambda x: (1 / (std * np.sqrt(2 * np.pi))) * np.exp(-0.5 * ((x - mean) / std) ** 2)
+        # Prior for a Gaussian constraint
+        'Gaussian': lambda mean, std: lambda x: (1 / (std * np.sqrt(2 * np.pi))) * np.exp(-0.5 * ((x - mean) / std) ** 2),
+
+        # Bimodal Gaussian Prior: Combines two Gaussians with optional weights
+        'BimodalGaussian': lambda mean1, std1, mean2, std2, bias=0.5: lambda x: (
+            bias * np.exp(-0.5 * ((x - mean1) / std1) ** 2) / (std1 * np.sqrt(2 * np.pi)) +
+            (1 - bias) * np.exp(-0.5 * ((x - mean2) / std2) ** 2) / (std2 * np.sqrt(2 * np.pi))
+        ),
+
+        # Step Prior for a binary bias
+        'Step': lambda bias, boundary=0: lambda x: np.where(x >= boundary, bias, 1 - bias)
     }
 
     def __init__(self):

--- a/numcmctools/jacobiangraph.py
+++ b/numcmctools/jacobiangraph.py
@@ -42,7 +42,7 @@ class JacobianGraph:
         ),
 
         # Step Prior for a binary bias
-        'Step': lambda bias, boundary=0: lambda x: np.where(x >= boundary, bias, 1 - bias)
+        'Step': lambda bias, boundary=0: lambda x: np.where(x >= boundary, 1 - bias, bias)
     }
 
     def __init__(self):

--- a/numcmctools/plotstack.py
+++ b/numcmctools/plotstack.py
@@ -87,7 +87,11 @@ class PlotStack:
         for batch in tqdm(self.chain.tree.iterate(step_size=batchsize, library="np", entry_stop=n_steps), total=n_batches):
 
             for var in self.plotted_variables:
+                # Skip variables that are already in the batch, unless they
+                # have an extra wrapper
                 if var in batch:
+                    if self.chain.variables[var].has_wrapper:
+                        batch[var] = self.chain.variables[var].evaluate(batch)
                     continue
                 batch[var] = self.chain.variables[var].evaluate(batch)
 

--- a/numcmctools/variable.py
+++ b/numcmctools/variable.py
@@ -15,6 +15,7 @@ class Variable:
         """
         self.name = name
         self.function = function
+        self.has_wrapper = False
 
     def evaluate(self, data: Dict[str, np.ndarray]) -> np.ndarray:
         """
@@ -29,14 +30,6 @@ class Variable:
         func_code = self.function.__code__
         arg_names = func_code.co_varnames[:func_code.co_argcount]
 
-        # Get keyword args for the transform function
-        #kwargs = {}
-        #for arg in arg_names:
-        #    if arg in data:
-        #        kwargs[arg] = data[arg]
-        #    else:
-        #        raise KeyError(f"Missing required argument '{arg}' in the input data. Use MCMCSamples.add_variable!")
-
         kwargs = {arg : data[arg] for arg in arg_names if arg in data}
 
         # Call the transform function!
@@ -44,6 +37,14 @@ class Variable:
             return self.function(**kwargs)
         except Exception as e:
             raise RuntimeError(f"Error evaluating variable '{self.name}': {e}")
+
+    def wrap_function(self, wrapper: Callable[..., np.ndarray]):
+        """
+        Wrap the current function with a new function
+        """
+
+        self.function = wrapper
+        self.has_wrapper = True
 
     def __repr__(self):
        return f"Variable(name='{self.name}', function='{self.function}')"


### PR DESCRIPTION
New features:
1. Two new prior types: `Step` and `BimodalGaussian`:
   - `Step` prior takes the bias (as a percentage, rather than BF), and optionally boundary location (0 by default), and applies the bias to the space before the boundary, 1 - bias to the space after the boundary.
   - `DoubleGaussian` takes `central1`, `width1`, `central2`, `width2`, and optionally, bias. Bias, once again, is applied to the first Gaussian, and 1 - bias is applied to the second gaussian.
   - **WARNING**: Currently, if user puts `bias` as 2, bias of 2 is applied to the first part of the posterior, and _negative bias applied to the other_
2. Wrapping dcp to 0--2pi by default, this was supposed to be in v1...

Tested writing new macros and checking whether a) dcp is looped, and b) bias of 0.66666 on both new prior types gives 2x difference in the posterior.