### PR TITLE
External 1D & 2D constraints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **.tar.gz
 **.whl
 **egg-info**
+**venv**

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ the package and add your own macros that include the `numcmcmtools` folder.
 
 ## File Format
 
+### MCMC samples
 The expected input format for this code is a ROOT file containing at
 least one TTree. The tree can have any name. Inside the tree, there
 will be at least six branches called:
@@ -48,9 +49,10 @@ first four are the PMNS angles, and the last two are the mass
 splittings. For more information on the parameterization see the [PDG
 review on neutrino mixing](https://pdg.lbl.gov/2024/web/viewer.html?file=../reviews/rpp2024-rev-neutrino-mixing.pdf).
 
-Each parameter has some prior set by the original analyzers. The
-format of this information is a TList containing a TNamed for each branch,
-which specifies the name of the branch and its prior.
+### Priors
+Each parameter has some prior set by the original analyzers. The format of this
+information is a `TList` object named `priors`, containing a `TNamed` for each
+branch, which specifies the name of the branch and its prior.
 
 The priors are specified as:
 1. `Uniform` 
@@ -65,8 +67,25 @@ applies to. For example, a specification of
 
 indicates that the prior for Theta23 is uniform in $\sin^2\theta_{23}$.
 
+### Constraints
+
+Optionally, file can contain 1D or 2D constraints to be applied by default to the plots when the `constraints` object input to `add_plot` function is set to `None`. For this, there needs to be a `TDirectoryFile` object named `constraints`. Each constraint object inside that directory can be either `TGraph2D` or `THnD`. The object must have a name in a format:
+
+1. unique name
+2. parameter names separated by colon, e.g. `sin^2(2Theta13):abs(Deltam2_32)`
+3. Optional string "NO" for constraint only applied to Normal Mass Ordering, IO for the Inverted mass ordering, or none for a constraint applied across both Mass Orderings.
+4. 1 if the constraint should be applied automatically, or 0 if not.
+
+Example:
+1. `DayaBay2D_2024_IO:sin^2(2Theta13):abs(Deltam2_32):IO:1` for a 2D constraint automatically applied in the Inverted Mass Ordering
+1. `some_constraint_from_theory:sin^2(2Theta13):sin^2(Theta23):1` for a 2D constraint automatically applied across both mass orderings.
+
+### Other
+
+
 The file additionally contains a citation to the original analysis that
-produced the chain.
+produced the chain. The citation must be inside of a `TObjString` object named
+`citation`.
 
 There may be additional information contained in the file; please see
 the data release from the particular analysis for more detail.

--- a/README.md
+++ b/README.md
@@ -67,20 +67,21 @@ applies to. For example, a specification of
 
 indicates that the prior for Theta23 is uniform in $\sin^2\theta_{23}$.
 
-### Constraints
+### Empirical priors
 
-Optionally, file can contain 1D or 2D constraints to be applied by default to the plots when the `constraints` object input to `add_plot` function is set to `None`. For this, there needs to be a `TDirectoryFile` object named `constraints`. Each constraint object inside that directory can be either `TGraph2D` or `THnD`. Additionally, a `TList` named `container_names` needs to be attached, with a detailed metadata for each external constraint. The `TNamed` entry inside of `TList` must be in a format:
+Optionally, file can contain 1D or 2D empirical priors to be applied by default to the plots when the `empirical_priors` object input to `add_plot` function is set to `None`. For this, there needs to be a `TDirectoryFile` object named `empirical_priors`. Each empirical prior object inside that directory can be either `TGraph2D` or `THnD`. Additionally, a `TList` named `priors` needs to contain, a detailed metadata for each external empirical prior. The `TNamed` entry inside of `TList` must be in a format:
 
 1. Name: unique name that matches `TNamed` inside of `TList`
+2. Title: `EmpiricalPrior` prefix, to distinguish this from the standard functional priors.
 2. Title: parameter names separated by colon, e.g. `sin^2(2Theta13):abs(Deltam2_32)`
-3. Title: Optional string "NO" for constraint only applied to Normal Mass Ordering, IO for the Inverted mass ordering, or none for a constraint applied across both Mass Orderings.
-4. Title: 1 if the constraint should be applied automatically, or 0 if not.
+3. Title: Optional string "NO" for empirical priors only applied to Normal Mass Ordering, IO for the Inverted mass ordering, or none for an empirical prior applied across both Mass Orderings.
+4. Title: 1 if the empirical prior should be applied automatically, or 0 if not.
 
 Example:
-1. `DayaBay2D_2024_IO` `sin^2(2Theta13):abs(Deltam2_32):IO:1` for a 2D constraint automatically applied in the Inverted Mass Ordering
-2. `some_constraint_from_theory` `sin^2(2Theta13):sin^2(Theta23):1` for a 2D constraint automatically applied across both mass orderings.
+1. `DayaBay2D_2024_IO` `EmpiricalPrior:sin^2(2Theta13):abs(Deltam2_32):IO:1` for a 2D constraint automatically applied in the Inverted Mass Ordering
+2. `some_constraint_from_theory` `EmpiricalPrior:sin^2(2Theta13):sin^2(Theta23):1` for a 2D constraint automatically applied across both mass orderings.
 
-The unique names in the `TList` must match the name of the `THnD` or `TGraph2D` inside of the `constraints` `TDirectory`. Example provided in `examples/testchaindata.root`
+The unique names for the empirical priors inside the `priors` `TList` must match the name of the `THnD` or `TGraph2D` inside of the `empirical_priors` `TDirectory`. Example provided in `examples/testchaindata.root`
 
 ### Other
 

--- a/README.md
+++ b/README.md
@@ -69,16 +69,18 @@ indicates that the prior for Theta23 is uniform in $\sin^2\theta_{23}$.
 
 ### Constraints
 
-Optionally, file can contain 1D or 2D constraints to be applied by default to the plots when the `constraints` object input to `add_plot` function is set to `None`. For this, there needs to be a `TDirectoryFile` object named `constraints`. Each constraint object inside that directory can be either `TGraph2D` or `THnD`. The object must have a name in a format:
+Optionally, file can contain 1D or 2D constraints to be applied by default to the plots when the `constraints` object input to `add_plot` function is set to `None`. For this, there needs to be a `TDirectoryFile` object named `constraints`. Each constraint object inside that directory can be either `TGraph2D` or `THnD`. Additionally, a `TList` named `container_names` needs to be attached, with a detailed metadata for each external constraint. The `TNamed` entry inside of `TList` must be in a format:
 
-1. unique name
-2. parameter names separated by colon, e.g. `sin^2(2Theta13):abs(Deltam2_32)`
-3. Optional string "NO" for constraint only applied to Normal Mass Ordering, IO for the Inverted mass ordering, or none for a constraint applied across both Mass Orderings.
-4. 1 if the constraint should be applied automatically, or 0 if not.
+1. Name: unique name that matches `TNamed` inside of `TList`
+2. Title: parameter names separated by colon, e.g. `sin^2(2Theta13):abs(Deltam2_32)`
+3. Title: Optional string "NO" for constraint only applied to Normal Mass Ordering, IO for the Inverted mass ordering, or none for a constraint applied across both Mass Orderings.
+4. Title: 1 if the constraint should be applied automatically, or 0 if not.
 
 Example:
-1. `DayaBay2D_2024_IO:sin^2(2Theta13):abs(Deltam2_32):IO:1` for a 2D constraint automatically applied in the Inverted Mass Ordering
-1. `some_constraint_from_theory:sin^2(2Theta13):sin^2(Theta23):1` for a 2D constraint automatically applied across both mass orderings.
+1. `DayaBay2D_2024_IO` `sin^2(2Theta13):abs(Deltam2_32):IO:1` for a 2D constraint automatically applied in the Inverted Mass Ordering
+2. `some_constraint_from_theory` `sin^2(2Theta13):sin^2(Theta23):1` for a 2D constraint automatically applied across both mass orderings.
+
+The unique names in the `TList` must match the name of the `THnD` or `TGraph2D` inside of the `constraints` `TDirectory`. Example provided in `examples/testchaindata.root`
 
 ### Other
 

--- a/examples/custom_variables.py
+++ b/examples/custom_variables.py
@@ -50,21 +50,21 @@ priors_expdcp = ["Uniform:sin(DeltaCP)",
                  "Gaussian(0.55, 0.01):sin^2(Theta23)"]
 
 # Applies default constrints from the MCMCSamples object
-# If empty list is provided, no constraints will be applied.
-constraints = None
+# If empty list is provided, no empirical_priors will be applied.
+empirical_priors = None
 
 # 1D plots
-stack.add_plot(["AbsUe3"], priors_expdcp, constraints, 50, [0.1, 0.25], True)
-stack.add_plot(["JarlskogInvariant"], priors_sindcp, constraints, 50, [-0.05, 0.05], True)
-stack.add_plot(["SinSqTheta23"], priors, constraints, 50, [0.35, 0.65])
-stack.add_plot(["SinSqTheta23"], priors, constraints, 50, [0.35, 0.65],True)
-stack.add_plot(["AbsDm2_32"],priors, constraints,50,[2.2E-3,2.8E-3],True)
+stack.add_plot(["AbsUe3"], priors_expdcp, empirical_priors, 50, [0.1, 0.25], True)
+stack.add_plot(["JarlskogInvariant"], priors_sindcp, empirical_priors, 50, [-0.05, 0.05], True)
+stack.add_plot(["SinSqTheta23"], priors, empirical_priors, 50, [0.35, 0.65])
+stack.add_plot(["SinSqTheta23"], priors, empirical_priors, 50, [0.35, 0.65],True)
+stack.add_plot(["AbsDm2_32"],priors, empirical_priors,50,[2.2E-3,2.8E-3],True)
 
 # 2D plots
-stack.add_plot(["JarlskogInvariant", "AbsUe3"], priors_expdcp, constraints, [50, 50], [[-0.05, 0.05], [0.1, 0.25]],True)
-stack.add_plot(["SinSqTheta23", "SinSq2Theta13"], priors, constraints, [50, 50], [[0.35, 0.65], [0.04, 0.15]])
-stack.add_plot(["JarlskogInvariant", "AbsSinDeltaCP"],priors_sindcp, constraints, [50, 50], [[-0.05, 0.05], [0, 1]])
-stack.add_plot(["SinSqTheta23", "AbsDm2_32"],priors, constraints, [50, 50], [[0.35, 0.65], [2.2E-3,2.8E-3]], True)
+stack.add_plot(["JarlskogInvariant", "AbsUe3"], priors_expdcp, empirical_priors, [50, 50], [[-0.05, 0.05], [0.1, 0.25]],True)
+stack.add_plot(["SinSqTheta23", "SinSq2Theta13"], priors, empirical_priors, [50, 50], [[0.35, 0.65], [0.04, 0.15]])
+stack.add_plot(["JarlskogInvariant", "AbsSinDeltaCP"],priors_sindcp, empirical_priors, [50, 50], [[-0.05, 0.05], [0, 1]])
+stack.add_plot(["SinSqTheta23", "AbsDm2_32"],priors, empirical_priors, [50, 50], [[0.35, 0.65], [2.2E-3,2.8E-3]], True)
 
 # Fill the plots
 stack.fill_plots()

--- a/examples/custom_variables.py
+++ b/examples/custom_variables.py
@@ -49,18 +49,22 @@ priors_sindcp = ["Uniform:sin(DeltaCP)",
 priors_expdcp = ["Uniform:sin(DeltaCP)",
                  "Gaussian(0.55, 0.01):sin^2(Theta23)"]
 
+# Applies default constrints from the MCMCSamples object
+# If empty list is provided, no constraints will be applied.
+constraints = None
+
 # 1D plots
-stack.add_plot(["AbsUe3"], priors_expdcp, 50, [0.1, 0.25], True)
-stack.add_plot(["JarlskogInvariant"], priors_sindcp, 50, [-0.05, 0.05], True)
-stack.add_plot(["SinSqTheta23"], priors, 50, [0.35, 0.65])
-stack.add_plot(["SinSqTheta23"], priors, 50, [0.35, 0.65],True)
-stack.add_plot(["AbsDm2_32"],priors,50,[2.2E-3,2.8E-3],True)
+stack.add_plot(["AbsUe3"], priors_expdcp, constraints, 50, [0.1, 0.25], True)
+stack.add_plot(["JarlskogInvariant"], priors_sindcp, constraints, 50, [-0.05, 0.05], True)
+stack.add_plot(["SinSqTheta23"], priors, constraints, 50, [0.35, 0.65])
+stack.add_plot(["SinSqTheta23"], priors, constraints, 50, [0.35, 0.65],True)
+stack.add_plot(["AbsDm2_32"],priors, constraints,50,[2.2E-3,2.8E-3],True)
 
 # 2D plots
-stack.add_plot(["JarlskogInvariant", "AbsUe3"], priors_expdcp, [50, 50], [[-0.05, 0.05], [0.1, 0.25]],True)
-stack.add_plot(["SinSqTheta23", "SinSq2Theta13"], priors, [50, 50], [[0.35, 0.65], [0.04, 0.15]])
-stack.add_plot(["JarlskogInvariant", "AbsSinDeltaCP"],priors_sindcp,[50, 50], [[-0.05, 0.05], [0, 1]])
-stack.add_plot(["SinSqTheta23", "AbsDm2_32"],priors,[50, 50], [[0.35, 0.65], [2.2E-3,2.8E-3]], True)
+stack.add_plot(["JarlskogInvariant", "AbsUe3"], priors_expdcp, constraints, [50, 50], [[-0.05, 0.05], [0.1, 0.25]],True)
+stack.add_plot(["SinSqTheta23", "SinSq2Theta13"], priors, constraints, [50, 50], [[0.35, 0.65], [0.04, 0.15]])
+stack.add_plot(["JarlskogInvariant", "AbsSinDeltaCP"],priors_sindcp, constraints, [50, 50], [[-0.05, 0.05], [0, 1]])
+stack.add_plot(["SinSqTheta23", "AbsDm2_32"],priors, constraints, [50, 50], [[0.35, 0.65], [2.2E-3,2.8E-3]], True)
 
 # Fill the plots
 stack.fill_plots()

--- a/examples/plot_triangle.py
+++ b/examples/plot_triangle.py
@@ -4,7 +4,7 @@ import os
 import numpy as np
 import matplotlib.pyplot as plt
 
-from numcmctools import PlotStack, MCMCSamples, ExternalConstraint
+from numcmctools import PlotStack, MCMCSamples, EmpiricalPrior
 
 # Define custom variable: ssth23
 def ssth23(Theta23) ->np.ndarray:
@@ -47,10 +47,10 @@ def main(file: str, chain_name: str):
   samples.add_variable("AbsDm32", absdm32)
   samples.add_variable("Dm21", scaleddm21)
 
-  # Constraints set to None means the default constraints from the MCMCSamples object will be used
-  # If empty list is provided, no constraints will be applied.
-  # If a list of unique external constraints is provided, those will be used.
-  constraints = None
+  # empirical_priors set to None means the default empirical_priors from the MCMCSamples object will be used
+  # If empty list is provided, no empirical priors will be applied.
+  # If a list of unique external empirical priors is provided, those will be used.
+  empirical_priors = None
 
   # Add all the 1D and 2D plots we want into the stack
   stack = PlotStack(samples)
@@ -59,9 +59,9 @@ def main(file: str, chain_name: str):
       if i < j:
         continue
       if i == j:
-        stack.add_plot([variable_names[i]], priors, constraints, bins[i], ranges[i], True)
+        stack.add_plot([variable_names[i]], priors, empirical_priors, bins[i], ranges[i], True)
       else:
-        stack.add_plot([variable_names[j], variable_names[i]], priors, constraints, [bins[j], bins[i]], [ranges[j], ranges[i]], True)
+        stack.add_plot([variable_names[j], variable_names[i]], priors, empirical_priors, [bins[j], bins[i]], [ranges[j], ranges[i]], True)
 
   # Fill the plots
   stack.fill_plots()

--- a/examples/plot_triangle.py
+++ b/examples/plot_triangle.py
@@ -4,7 +4,7 @@ import os
 import numpy as np
 import matplotlib.pyplot as plt
 
-from numcmctools import PlotStack, MCMCSamples
+from numcmctools import PlotStack, MCMCSamples, ExternalConstraint
 
 # Define custom variable: ssth23
 def ssth23(Theta23) ->np.ndarray:
@@ -36,7 +36,7 @@ def main(file: str, chain_name: str):
   ranges = [[0, 2*np.pi], [0.03, 0.16], [0.35, 0.65], [0.78, 0.91], [2.15, 2.65], [6, 9]]
 
   priors = ["Uniform:DeltaCP",
-            "Gaussian(0.085,0.003):sin^2(2Theta13)",
+            "Uniform:sin^2(2Theta13)",
             "Uniform:sin^2(2Theta12)",
             "Uniform:sin^2(Theta23)"]
 
@@ -47,6 +47,11 @@ def main(file: str, chain_name: str):
   samples.add_variable("AbsDm32", absdm32)
   samples.add_variable("Dm21", scaleddm21)
 
+  # Constraints set to None means the default constraints from the MCMCSamples object will be used
+  # If empty list is provided, no constraints will be applied.
+  # If a list of unique external constraints is provided, those will be used.
+  constraints = None
+
   # Add all the 1D and 2D plots we want into the stack
   stack = PlotStack(samples)
   for i, pl_i in enumerate(variable_names):
@@ -54,9 +59,9 @@ def main(file: str, chain_name: str):
       if i < j:
         continue
       if i == j:
-        stack.add_plot([variable_names[i]], priors, bins[i], ranges[i], True)
+        stack.add_plot([variable_names[i]], priors, constraints, bins[i], ranges[i], True)
       else:
-        stack.add_plot([variable_names[j], variable_names[i]], priors, [bins[j], bins[i]], [ranges[j], ranges[i]], True)
+        stack.add_plot([variable_names[j], variable_names[i]], priors, constraints, [bins[j], bins[i]], [ranges[j], ranges[i]], True)
 
   # Fill the plots
   stack.fill_plots()

--- a/examples/simpleplots.py
+++ b/examples/simpleplots.py
@@ -17,8 +17,8 @@ samples = MCMCSamples(root_file_path, "mcmc")
 stack = PlotStack(samples)
 
 #define a 1D and 2D plot; note the 1D plot has both non-equal bins and is split by mass-ordering
-stack.add_plot(["Deltam2_32", "Theta23"],[],[50,50],[[2.2E-3,2.7E-3],[0.7,0.9]])
-stack.add_plot(["DeltaCP_pipi"],[],[-np.pi, -0.95*np.pi, -0.9*np.pi, -0.85*np.pi, -0.8*np.pi, -0.75*np.pi,
+stack.add_plot(["Deltam2_32", "Theta23"],[],[],[50,50],[[2.2E-3,2.7E-3],[0.7,0.9]])
+stack.add_plot(["DeltaCP_pipi"],[],[],[-np.pi, -0.95*np.pi, -0.9*np.pi, -0.85*np.pi, -0.8*np.pi, -0.75*np.pi,
                                    -0.7*np.pi,  -0.65*np.pi,  -0.6*np.pi,  -0.55*np.pi,  -0.5*np.pi,
                                     -0.45*np.pi,  -0.4*np.pi,  -0.35*np.pi,  -0.3*np.pi,  -0.25*np.pi,
                                      -0.2*np.pi,  -0.15*np.pi,  -0.1*np.pi,  -0.05*np.pi, 0,

--- a/numcmctools/__init__.py
+++ b/numcmctools/__init__.py
@@ -5,7 +5,7 @@ from numcmctools.plotstack import PlotStack
 from numcmctools.plot import Plot 
 from numcmctools.jacobiangraph import JacobianGraph
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s::%(levelname)s::%(name)s: - %(message)s')
+logging.basicConfig(level=logging.INFO, format='%(asctime)s::%(levelname)s::%(name)s::%(lineno)s: - %(message)s')
 
 def set_external_logging_level(level):
     """

--- a/numcmctools/__init__.py
+++ b/numcmctools/__init__.py
@@ -4,6 +4,7 @@ from numcmctools.variable import Variable
 from numcmctools.plotstack import PlotStack
 from numcmctools.plot import Plot 
 from numcmctools.jacobiangraph import JacobianGraph
+from numcmctools.constraints import ExternalConstraint
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s::%(levelname)s::%(name)s::%(lineno)s: - %(message)s')
 

--- a/numcmctools/__init__.py
+++ b/numcmctools/__init__.py
@@ -4,7 +4,7 @@ from numcmctools.variable import Variable
 from numcmctools.plotstack import PlotStack
 from numcmctools.plot import Plot 
 from numcmctools.jacobiangraph import JacobianGraph
-from numcmctools.constraints import ExternalConstraint
+from numcmctools.empirical_priors import EmpiricalPrior
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s::%(levelname)s::%(name)s::%(lineno)s: - %(message)s')
 

--- a/numcmctools/constraints.py
+++ b/numcmctools/constraints.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 class ExternalConstraint:
     _INTERPOLATORS = ['regular', 'linear']
 
-    def __init__(self, root_obj, variables, interpolator_type: str ='regular'):
+    def __init__(self, root_obj, variables, interpolator_type: str ='linear'):
         type_name = type(root_obj).__name__
         logger.debug(f"Initializing ExternalConstraint with input root object type: {type_name}")
         if "THnT" in type_name: 

--- a/numcmctools/constraints.py
+++ b/numcmctools/constraints.py
@@ -1,0 +1,81 @@
+import uproot
+import numpy as np
+import logging
+from scipy.interpolate import LinearNDInterpolator, RegularGridInterpolator
+from types import FunctionType
+
+logger = logging.getLogger(__name__)
+
+class ExternalConstraint:
+    _INTERPOLATORS = ['regular', 'linear']
+
+    def __init__(self, root_obj, interpolator_type: str ='regular'):
+        type_name = type(root_obj).__name__
+        logger.debug(f"Initializing ExternalConstraint with input root object type: {type_name}")
+        if "THnT" in type_name: 
+            self._init_thnd(root_obj)
+        elif "TGraph2D" in type_name:
+            self._init_tgraph2d(root_obj)
+        else:
+            raise ValueError(f"The provided object is not a valid THnT or TGraph2D object. Got {type_name}.")
+
+        if interpolator_type not in self._INTERPOLATORS:
+            raise ValueError(f"Invalid interpolator type. Choose from {self._INTERPOLATORS}. Got {interpolator_type}.") 
+        
+        self._init_interpolator(interpolator_type)
+        logger.debug(f"ExternalConstraint object initialized with {self.dimensions} dimensions "\
+                    f"and {self.interpolate.__class__.__name__} interpolation.")
+    
+    def _init_thnd(self, thnd):
+        # Throw if the number of dimensions is greater than 2
+        self.dimensions: int = thnd.member("fNdimensions")
+        if self.dimensions > 2:
+            raise ValueError("External constraints with more than 2 dimensions are not supported yet.")
+        logger.debug(f"Initializing THnD-constraint with {self.dimensions} dimensions.")
+
+        # Get the axes and their properties
+        axes =  thnd.member(f"fAxes")
+        shape  = tuple(int(ax.member("fNbins")) for ax in axes)
+        mins = tuple(ax.member("fXmin") for ax in axes)
+        maxs = tuple(ax.member("fXmax") for ax in axes)
+
+        # Expand the mins and maxes to take the underflow and overflow bins intothe account, 
+        # and move the bins to the center
+        step =  tuple((mx - m) / (2*s) for m, mx, s in zip(mins, maxs, shape))
+        mins = tuple(m - step[i] for i, m in enumerate(mins))
+        maxs = tuple(mx + step[i] for i, mx in enumerate(maxs))
+        shape = tuple(s + 2 for s in shape)
+
+        # Load the data from the THnT object
+        self.data: np.ndarray = np.array(thnd.member("fArray").member("fData"), dtype=float)
+        self.data = self.data.reshape(shape)
+
+        # Create the bins
+        self.points = np.asarray(tuple(np.linspace(m, mx, s) for m, mx, s in zip(mins, maxs, shape)))
+        logger.debug(f"Points shape: {self.points.shape}, z data shape: {self.data.shape}")
+    
+    def _init_tgraph2d(self, tgraph2d):
+        raise NotImplementedError("TGraph2D support is not implemented yet.")
+    
+    def _init_interpolator(self, interpolator_type: str):
+
+        if interpolator_type == 'linear':
+            # Linear interpolation requires a meshgrid of points for the Delaunay triangulation
+            self.points = np.column_stack([p.ravel() for p in np.meshgrid(*self.points)])
+            self.interpolate = LinearNDInterpolator(self.points,
+                                                    np.ravel(self.data.T),
+                                                    fill_value=0.0,
+                                                    rescale=True)
+
+        elif interpolator_type == 'regular':
+            self.interpolate = RegularGridInterpolator(self.points,
+                                                       self.data,
+                                                       method='linear',
+                                                       bounds_error=False,
+                                                       fill_value=0.0)
+        
+        logger.debug(f"Interpolator initialized: {self.interpolate.__class__.__name__}")
+
+    def __repr__(self):
+        return f"ExternalConstraint(interp_type={self.interpolate.__class__.__name__}, " \
+               f"dims={self.dimensions})"

--- a/numcmctools/constraints.py
+++ b/numcmctools/constraints.py
@@ -67,8 +67,6 @@ class ExternalConstraint:
 
         points = []
         for axis, is_increasing in zip(['fX', 'fY'], [x_increasing, y_increasing]):
-            print(f"Dimension: {axis}, Increasing: {is_increasing}")
-
             if is_increasing:
                 npoints = np.where(np.diff(tgraph2d.member(axis)) < 0)[0] + 1
                 points.append(tgraph2d.member(axis)[0:npoints[0]])

--- a/numcmctools/empirical_priors.py
+++ b/numcmctools/empirical_priors.py
@@ -6,12 +6,12 @@ from types import FunctionType
 
 logger = logging.getLogger(__name__)
 
-class ExternalConstraint:
+class EmpiricalPrior:
     _INTERPOLATORS = ['regular', 'linear']
 
     def __init__(self, root_obj, variables, interpolator_type: str ='linear'):
         type_name = type(root_obj).__name__
-        logger.debug(f"Initializing ExternalConstraint with input root object type: {type_name}")
+        logger.debug(f"Initializing EmpiricalPrior with input root object type: {type_name}")
         if "THnT" in type_name: 
             self._init_thnd(root_obj)
         elif "TGraph2D" in type_name:
@@ -23,7 +23,7 @@ class ExternalConstraint:
             raise ValueError(f"Invalid interpolator type. Choose from {self._INTERPOLATORS}. Got {interpolator_type}.") 
         
         self._init_interpolator(interpolator_type)
-        logger.debug(f"ExternalConstraint object initialized with {self.dimensions} dimensions "\
+        logger.debug(f"EmpiricalPrior object initialized with {self.dimensions} dimensions "\
                     f"and {self.interpolate.__class__.__name__} interpolation.")
 
         self.variables = variables
@@ -32,8 +32,8 @@ class ExternalConstraint:
         # Throw if the number of dimensions is greater than 2
         self.dimensions: int = thnd.member("fNdimensions")
         if self.dimensions > 2:
-            raise ValueError("External constraints with more than 2 dimensions are not supported yet.")
-        logger.debug(f"Initializing THnD-constraint with {self.dimensions} dimensions.")
+            raise ValueError("External empirical prior with more than 2 dimensions are not supported yet.")
+        logger.debug(f"Initializing THnD-empirical prior with {self.dimensions} dimensions.")
 
         # Get the axes and their properties
         axes =  thnd.member(f"fAxes")
@@ -111,5 +111,5 @@ class ExternalConstraint:
         
 
     def __repr__(self):
-        return f"ExternalConstraint(interp_type={self.interpolate.__class__.__name__}, " \
+        return f"EmpiricalPrior(interp_type={self.interpolate.__class__.__name__}, " \
                f"dims={self.dimensions})"

--- a/numcmctools/mcmcsamples.py
+++ b/numcmctools/mcmcsamples.py
@@ -42,6 +42,8 @@ class MCMCSamples:
         self.__check_and_extract_variables()
         # Get self.priors
         self.__check_and_extract_priors()
+        # Get self.constraints
+        self.__check_and_extract_constraints()
         # Get citation
         self.citation = uproot.open(f"{self.filepath}:citation")
 
@@ -69,7 +71,7 @@ class MCMCSamples:
                self.variables[var] = Variable(var, __create_identity_function(var))
 
                # Wrap dcp
-               if var is "DeltaCP":
+               if var == "DeltaCP":
                    self.variables[var].wrap_function(__dcp_wrapper)
 
                logger.debug(f"Compulsory variable {var} found in the root file")
@@ -103,6 +105,69 @@ class MCMCSamples:
         self.variables["JarlskogInvariant"] = Variable("JarlskogInvariant", jarlskog_invariant)
         self.variables["DeltaCP_02pi"] = Variable("DeltaCP_02pi", deltacp_02pi)
         self.variables["DeltaCP_pipi"] = Variable("DeltaCP_pipi", deltacp_pipi)
+    
+    def __parse_constraint_name(self, name: str):
+        """
+        Parse the constraint name to extract the variable names, mass ordering,
+        and whether the default is applied.
+        The expected format is:
+        "unique_name:var1:var2:...:varN:mass_ordering[:default]:applied_default"
+
+        :param name: The name of the constraint.
+        :return: Tuple containing (name, vars, mass_ordering, applied_default).
+        """
+        parts = name.split(":")
+        if len(parts) < 3 or len(parts) > 5:
+            raise ValueError(f"Invalid constraint name format: {name}. Expected at least 3 parts separated by ':'.")
+
+        # Extract the unique name and variables
+        unique_name = parts[0]
+        is_applied_default = int(parts[-1])
+
+        # TODO need extra checks to see how many parts there are, and if user provided e.g. wrong string for MO
+        if parts[-2] in ["NO", "IO"]:
+            mass_ordering = parts[-2]
+            vars = parts[1:-2]
+        else:
+            mass_ordering = "NOIO"
+            vars = parts[1:-1]
+        
+        return unique_name, vars, mass_ordering, is_applied_default
+
+
+    def __check_and_extract_constraints(self):
+        # Open the object with the constraints
+        try:
+            constraints = uproot.open(f"{self.filepath}:constraints")
+        except uproot.exceptions.KeyInFileError:
+            logger.warning("No \"constraints\" TDirectionaryFile found in the ROOT file. Skipping constraints extraction.")
+            return
+
+        logger.warning("\"Constraints\" TDirectionaryFile found in the ROOT file. Reading")
+
+        # Iterate over objects in the constraints TDirectory
+        for obj_name in constraints.keys():
+            # Remove the ;1 if exists
+            obj_name = obj_name[:obj_name.rindex(";")]
+
+            # Parse the constraint name to extract the unique name, variables,
+            # mass ordering, and whether the constraint should be applied by default
+            name, vars, mass_ordering, applied_default = self.__parse_constraint_name(obj_name)
+
+            # Add the variable if it does not exist
+            vars_for_constraint:List[str] = []
+            for var in vars:
+                if var not in self.variables:
+                    func = JacobianGraph.variable_to_func(var, self.compulsory_variables)
+                    self.add_variable(var, func)
+                vars_for_constraint.append(var)
+
+            # Add the constraint
+            self.add_constraint(name,
+                                ExternalConstraint(constraints[obj_name], 
+                                                   vars_for_constraint),
+                                is_inverted=("IO" in mass_ordering),
+                                is_normal=("NO" in mass_ordering))
 
     def add_variable(self, name: str, function: Callable[..., np.ndarray]):
         """
@@ -114,6 +179,8 @@ class MCMCSamples:
                          The function can accept keyqord arguments where keys match the names of
                          already defined variables.
         """
+
+        logger.debug(f"Adding variable '{name}' to MCMCSamples object.")
         if name in self.variables:
            raise ValueError(f"Variable '{name}' is already defined!")
 
@@ -140,6 +207,8 @@ class MCMCSamples:
         if not is_inverted and not is_normal:
             raise ValueError("At least one of is_inverted or is_normal must be True")
 
+        logger.debug(f"Adding constraint '{name}' with {constraint} to MCMCSamples object.")
+            
         self.constraints[name] = constraint
         self.constraints[name].is_inverted = is_inverted
         self.constraints[name].is_normal = is_normal

--- a/numcmctools/mcmcsamples.py
+++ b/numcmctools/mcmcsamples.py
@@ -1,9 +1,10 @@
 import uproot
 import numpy as np
 import logging, sys
-from typing import Callable, Dict
+from typing import Callable, Dict, List
 from .variable import Variable
 from .jacobiangraph import JacobianGraph
+from .constraints import ExternalConstraint
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +38,7 @@ class MCMCSamples:
         # Get self.variables
         self.variables = {}
         self.variable_priors = {}
+        self.constraints = {}
         self.__check_and_extract_variables()
         # Get self.priors
         self.__check_and_extract_priors()
@@ -116,6 +118,31 @@ class MCMCSamples:
            raise ValueError(f"Variable '{name}' is already defined!")
 
         self.variables[name] = Variable(name, function)
+
+    def add_constraint(self, name: str,
+                       constraint: ExternalConstraint,
+                       is_inverted: bool = True,
+                       is_normal: bool = True):
+        """
+        Add an external constraint to the MCMCSamples object.
+
+        :param name: Unique name of the constraint.
+        :param constraint: An instance of ExternalConstraint.
+        :param is_inverted: If the constraint for the inverted ordering.
+        :param is_normal: If the constraint for the normal ordering.
+        """
+        if name in self.constraints:
+            raise ValueError(f"Constraint named {name} already exists!")
+
+        if not isinstance(constraint, ExternalConstraint):
+            raise TypeError("Constraint must be an instance of ExternalConstraint")
+        
+        if not is_inverted and not is_normal:
+            raise ValueError("At least one of is_inverted or is_normal must be True")
+
+        self.constraints[name] = constraint
+        self.constraints[name].is_inverted = is_inverted
+        self.constraints[name].is_normal = is_normal
 
     def __check_and_extract_priors(self):
         """

--- a/numcmctools/mcmcsamples.py
+++ b/numcmctools/mcmcsamples.py
@@ -4,7 +4,7 @@ import logging, sys
 from typing import Callable, Dict, List
 from .variable import Variable
 from .jacobiangraph import JacobianGraph
-from .constraints import ExternalConstraint
+from .empirical_priors import EmpiricalPrior
 
 logger = logging.getLogger(__name__)
 
@@ -36,12 +36,10 @@ class MCMCSamples:
         # Get self.variables
         self.variables = {}
         self.variable_priors = {}
-        self.constraints = {}
+        self.empirical_priors= {}
         self.__check_and_extract_variables()
         # Get self.priors
         self.__check_and_extract_priors()
-        # Get self.constraints
-        self.__check_and_extract_constraints()
         # Get citation
         self.citation = uproot.open(f"{self.filepath}:citation")
 
@@ -104,19 +102,22 @@ class MCMCSamples:
         self.variables["DeltaCP_02pi"] = Variable("DeltaCP_02pi", deltacp_02pi)
         self.variables["DeltaCP_pipi"] = Variable("DeltaCP_pipi", deltacp_pipi)
     
-    def __parse_constraint_name(self, title: str):
+    def __parse_empirical_prior_name(self, title: str):
         """
-        Parse the constraint name to extract the variable names, mass ordering,
+        Parse the empirical prior name to extract the variable names, mass ordering,
         and whether the default is applied.
         The expected format is:
-        "unique_name:var1:var2:...:varN:mass_ordering[:default]:applied_default"
+        "EmpiricalPrior:var1:var2:...:varN:mass_ordering[:default]:applied_default"
 
-        :param name: The name of the constraint.
+        :param name: The name of the empirical prior.
         :return: Tuple containing (name, vars, mass_ordering, applied_default).
         """
         parts = title.split(":")
-        if len(parts) < 2 or len(parts) > 4:
-            raise ValueError(f"Invalid constraint name format: {title}. Expected at least 2 parts separated by ':'.")
+        if len(parts) < 3 or len(parts) > 5:
+            raise ValueError(f"Invalid empirical prior name format: {title}. Expected at least 3 parts separated by ':'.")
+        
+        if parts[0] != "EmpiricalPrior":
+            raise ValueError(f"Invalid empirical prior name format: {title}. Must start with 'EmpiricalPrior'.")
 
         # Extract the unique name and variables
         is_applied_default = int(parts[-1])
@@ -124,55 +125,49 @@ class MCMCSamples:
         # TODO need extra checks to see how many parts there are, and if user provided e.g. wrong string for MO
         if parts[-2] in ["NO", "IO"]:
             mass_ordering = parts[-2]
-            vars = parts[0:-2]
+            vars = parts[1:-2]
         else:
             mass_ordering = "NOIO"
-            vars = parts[0:-1]
+            vars = parts[1:-1]
         
         return vars, mass_ordering, is_applied_default
-
-    def __check_and_extract_constraints(self):
-        # Open the object with the constraints
-        try:
-            constraints = uproot.open(f"{self.filepath}:constraints")
-        except uproot.exceptions.KeyInFileError:
-            logger.warning("No \"constraints\" TDirectionaryFile found in the ROOT file. Skipping constraints extraction.")
-            return
-        
-        try:
-            constraint_name_list = uproot.open(f"{self.filepath}:constraint_names")
-        except uproot.exceptions.KeyInFileError:
-            logger.warning("No \"constraint_names\" TList found in the ROOT file. Skipping constraints extraction.")
+    
+    def __extract_empirical_priors(self, empirical_priors: Dict[str, str]):
+        # No empirical priors to extract
+        if not empirical_priors:
             return
 
-        # Create dictionary of constraint names to the constraint metadata
-        constraint_name_dict = {c.member('fName'): c.member('fTitle') for c in constraint_name_list}
-        
-        for obj_name in constraints.keys():
-            # Remove the ;1 if exists
-            obj_name = obj_name[:obj_name.rindex(";")]
-            if obj_name not in constraint_name_dict:
-                raise ValueError(f"Constraint '{obj_name}' not found in the constraints TDirectory. Available: {list(constraint_name_dict.keys())}")
+        # Open the object with the empirical priors
+        try:
+            prior_surfaces = uproot.open(f"{self.filepath}:empirical_priors")
+        except uproot.exceptions.KeyInFileError:
+            logger.warning("No \"empirical_priors\" TDirectionaryFile found in the ROOT file. Skipping empirical prior extraction.")
+            return
 
-            # Parse the constraint name to extract the unique name, variables,
-            # mass ordering, and whether the constraint should be applied by default
-            vars, mass_ordering, applied_default = self.__parse_constraint_name(constraint_name_dict[obj_name])
+        for obj_name in empirical_priors.keys():
+
+            if obj_name not in prior_surfaces:
+                raise ValueError(f"Empirical prior '{obj_name}' not found in the empirical_priors TDirectory. Available: {list(prior_surfaces.keys())}")
+
+            # Parse the empirical prior name to extract the unique name, variables,
+            # mass ordering, and whether the empirical prior should be applied by default
+            vars, mass_ordering, applied_default = self.__parse_empirical_prior_name(empirical_priors[obj_name])
 
             # Add the variable if it does not exist
-            vars_for_constraint:List[str] = []
+            vars_for_empirical_prior:List[str] = []
             for var in vars:
                 if var not in self.variables:
                     func = JacobianGraph.variable_to_func(var, self.compulsory_variables)
                     self.add_variable(var, func)
-                vars_for_constraint.append(var)
+                vars_for_empirical_prior.append(var)
 
-            # Add the constraint
-            self._add_default_constraint(obj_name,
-                                         ExternalConstraint(constraints[obj_name], 
-                                                         vars_for_constraint),
-                                         is_inverted=("IO" in mass_ordering),
-                                         is_normal=("NO" in mass_ordering),
-                                         is_applied_default=applied_default)
+            # Add the empirical prior
+            self._add_default_empirical_prior(obj_name,
+                                              EmpiricalPrior(prior_surfaces[obj_name], 
+                                                                 vars_for_empirical_prior),
+                                              is_inverted=("IO" in mass_ordering),
+                                              is_normal=("NO" in mass_ordering),
+                                              is_applied_default=applied_default)
 
     def add_variable(self, name: str, function: Callable[..., np.ndarray]):
         """
@@ -191,52 +186,53 @@ class MCMCSamples:
 
         self.variables[name] = Variable(name, function)
 
-    def _add_default_constraint(self, name: str,
-                                constraint: ExternalConstraint,
-                                is_inverted: bool = True,
-                                is_normal: bool = True,
-                                is_applied_default: bool = True):
-        self.add_constraint(name, constraint,
+    def _add_default_empirical_prior(self, name: str,
+                                     empirical_prior: EmpiricalPrior,
+                                     is_inverted: bool = True,
+                                     is_normal: bool = True,
+                                     is_applied_default: bool = True):
+
+        self.add_empirical_prior(name, empirical_prior,
                             is_inverted=is_inverted,
                             is_normal=is_normal)
         
-        self.constraints[name].applied_default = is_applied_default
+        self.empirical_priors[name].applied_default = is_applied_default
         if is_applied_default:
             if is_inverted and is_normal:
                 mo = "Both Mass Orderings"
             else:
                 mo = "Inverted Mass Ordering" if is_inverted else "Normal Mass Ordering" if is_normal else ''
 
-            logger.info(f"Default constraint '{name}' added for variables {constraint.variables} and {mo}. "
-                        f"Applied by default if the 'constraint' in add_plot function is 'None' rather than an empty list.")
+            logger.info(f"Default empirical prior '{name}' added for variables {empirical_prior.variables} and {mo}. "
+                        f"Applied by default if the 'empirical_prior' in add_plot function is 'None' rather than an empty list.")
 
-    def add_constraint(self, name: str,
-                       constraint: ExternalConstraint,
-                       is_inverted: bool = True,
-                       is_normal: bool = True):
+    def add_empirical_prior(self, name: str,
+                            empirical_prior: EmpiricalPrior,
+                            is_inverted: bool = True,
+                            is_normal: bool = True):
         """
-        Add an external constraint to the MCMCSamples object.
+        Add an empirical prior to the MCMCSamples object.
 
-        :param name: Unique name of the constraint.
-        :param constraint: An instance of ExternalConstraint.
-        :param is_inverted: If the constraint for the inverted ordering.
-        :param is_normal: If the constraint for the normal ordering.
+        :param name: Unique name of the empirical prior.
+        :param empirical_prior: An instance of EmpiricalPrior.
+        :param is_inverted: If the empirical prior for the inverted ordering.
+        :param is_normal: If the empirical prior for the normal ordering.
         """
-        if name in self.constraints:
-            raise ValueError(f"Constraint named {name} already exists!")
+        if name in self.empirical_priors:
+            raise ValueError(f"Empirical prior named {name} already exists!")
 
-        if not isinstance(constraint, ExternalConstraint):
-            raise TypeError("Constraint must be an instance of ExternalConstraint")
+        if not isinstance(empirical_prior, EmpiricalPrior):
+            raise TypeError("Empirical prior must be an instance of EmpiricalPrior class!")
         
         if not is_inverted and not is_normal:
             raise ValueError("At least one of is_inverted or is_normal must be True")
 
-        logger.debug(f"Adding constraint '{name}' with {constraint} to MCMCSamples object.")
+        logger.debug(f"Adding empirical prior '{name}' with {empirical_prior} to MCMCSamples object.")
             
-        self.constraints[name] = constraint
-        self.constraints[name].is_inverted = is_inverted
-        self.constraints[name].is_normal = is_normal
-        self.constraints[name].applied_default = False
+        self.empirical_priors[name] = empirical_prior 
+        self.empirical_priors[name].is_inverted = is_inverted
+        self.empirical_priors[name].is_normal = is_normal
+        self.empirical_priors[name].applied_default = False
 
     def __check_and_extract_priors(self):
         """
@@ -246,7 +242,9 @@ class MCMCSamples:
         # Open the prior TList
         tlist_priors = uproot.open(f"{self.filepath}:priors")
 
-        priors = []
+        priors: List[str] = []
+        empirical_priors: Dict[str, str] = {}
+
         # Iterate over the TNamed objects and extract priors
         for p in tlist_priors:
             name = p.member('fName')
@@ -254,6 +252,8 @@ class MCMCSamples:
             if name in self.variables:
                 priors.append(prior)
                 logger.debug(f"Prior for {name} found, with format: {prior}")
+            elif "EmpiricalPrior" in prior:
+                empirical_priors[name] = prior
             else:
                 # Don't try to fill prior for variable that does not exist!
                 raise ValueError(f"Prior defined for {name}, but variable {name} does not exist!")
@@ -265,6 +265,9 @@ class MCMCSamples:
         for v in self.compulsory_variables:
             if v not in self.variable_priors:
                 raise ValueError(f"No prior for {v} defined in the root file!")
+        
+        # Now parse the non-functional priors
+        self.__extract_empirical_priors(empirical_priors)
 
     def __repr__(self):
        """

--- a/numcmctools/mcmcsamples.py
+++ b/numcmctools/mcmcsamples.py
@@ -143,7 +143,7 @@ class MCMCSamples:
             logger.warning("No \"constraints\" TDirectionaryFile found in the ROOT file. Skipping constraints extraction.")
             return
 
-        logger.warning("\"Constraints\" TDirectionaryFile found in the ROOT file. Reading")
+        logger.debug("The \"constraints\" TDirectionaryFile found in the ROOT file. Reading")
 
         # Iterate over objects in the constraints TDirectory
         for obj_name in constraints.keys():
@@ -197,6 +197,14 @@ class MCMCSamples:
                             is_normal=is_normal)
         
         self.constraints[name].applied_default = is_applied_default
+        if is_applied_default:
+            if is_inverted and is_normal:
+                mo = "Both Mass Orderings"
+            else:
+                mo = "Inverted Mass Ordering" if is_inverted else "Normal Mass Ordering" if is_normal else ''
+
+            logger.info(f"Default constraint '{name}' added for variables {constraint.variables} and {mo}. "
+                        f"Applied by default if the 'constraint' in add_plot function is 'None' rather than an empty list.")
 
     def add_constraint(self, name: str,
                        constraint: ExternalConstraint,

--- a/numcmctools/mcmcsamples.py
+++ b/numcmctools/mcmcsamples.py
@@ -163,11 +163,12 @@ class MCMCSamples:
                 vars_for_constraint.append(var)
 
             # Add the constraint
-            self.add_constraint(name,
-                                ExternalConstraint(constraints[obj_name], 
-                                                   vars_for_constraint),
-                                is_inverted=("IO" in mass_ordering),
-                                is_normal=("NO" in mass_ordering))
+            self._add_default_constraint(name,
+                                         ExternalConstraint(constraints[obj_name], 
+                                                         vars_for_constraint),
+                                         is_inverted=("IO" in mass_ordering),
+                                         is_normal=("NO" in mass_ordering),
+                                         is_applied_default=applied_default)
 
     def add_variable(self, name: str, function: Callable[..., np.ndarray]):
         """
@@ -185,6 +186,17 @@ class MCMCSamples:
            raise ValueError(f"Variable '{name}' is already defined!")
 
         self.variables[name] = Variable(name, function)
+
+    def _add_default_constraint(self, name: str,
+                                constraint: ExternalConstraint,
+                                is_inverted: bool = True,
+                                is_normal: bool = True,
+                                is_applied_default: bool = True):
+        self.add_constraint(name, constraint,
+                            is_inverted=is_inverted,
+                            is_normal=is_normal)
+        
+        self.constraints[name].applied_default = is_applied_default
 
     def add_constraint(self, name: str,
                        constraint: ExternalConstraint,
@@ -212,6 +224,7 @@ class MCMCSamples:
         self.constraints[name] = constraint
         self.constraints[name].is_inverted = is_inverted
         self.constraints[name].is_normal = is_normal
+        self.constraints[name].applied_default = False
 
     def __check_and_extract_priors(self):
         """

--- a/numcmctools/plot.py
+++ b/numcmctools/plot.py
@@ -80,15 +80,13 @@ class Plot:
                 raise ValueError(f"Constraint {constraint} must be either inverted or normal")
             
             weights_tmp = self.constraints[constraint](data)
-            def_weight = 1.0
 
-            #if self.constraints[constraint].is_inverted and self.constraints[constraint].is_normal:
-            #    def_weight = 1.0
-            
-            if self.constraints[constraint].is_inverted:
-                weights *= np.where(np.less_equal(data["Deltam2_32"],0.0), weights_tmp, def_weight)
-            if self.constraints[constraint].is_normal:
-                weights *= np.where(np.greater_equal(data["Deltam2_32"],0.0), weights_tmp, def_weight)
+            if self.constraints[constraint].is_inverted and self.constraints[constraint].is_normal:
+                weights *= weights_tmp
+            elif self.constraints[constraint].is_inverted:
+                weights *= np.where(np.less_equal(data["Deltam2_32"],0.0), weights_tmp, 1.0)
+            elif self.constraints[constraint].is_normal:
+                weights *= np.where(np.greater_equal(data["Deltam2_32"],0.0), weights_tmp, 1.0)
         
         if not self.finalized:
             if(self.nvar==1):

--- a/numcmctools/plotstack.py
+++ b/numcmctools/plotstack.py
@@ -24,7 +24,7 @@ class PlotStack:
         self.plotted_variables = []
         self.plots = []
 
-    def add_plot(self,variables, priors, bins, axrange=None, mo_option=False):
+    def add_plot(self,variables, priors, constraints, bins, axrange=None, mo_option=False):
         """
         Add a plot to the stack
   
@@ -56,6 +56,15 @@ class PlotStack:
                 else:
                     logger.debug(f"Prior for variable {var} supplied in plot: {variables}: {parsed_priors[var]}")
                     plot_jacobians[var] = self.jacobian_graph.get_jacobian_func(self.chain.variable_priors[var], parsed_priors[var])
+        
+        # Add the constraints to the plotting function
+        plot_constraints = {}
+        for constraint in constraints:
+            if constraint not in self.chain.constraints:
+                raise TypeError(f"The constraint you supplied in plot, {constraint}, is not defined in the MCMCSamples chain")
+
+            logger.debug(f"Constraint for variable {constraint} supplied in plot: {variables}: {self.chain.constraints[constraint]}")
+            plot_constraints[constraint] = self.chain.constraints[constraint]
 
         # Crash if user supplied a non-existant variable
         for var in variables:
@@ -68,7 +77,7 @@ class PlotStack:
                 continue
             self.plotted_variables.append(var)
 
-        self.plots.append(Plot(variables, plot_jacobians, bins, axrange, mo_option))
+        self.plots.append(Plot(variables, plot_jacobians, plot_constraints, bins, axrange, mo_option))
 
     def fill_plots(self,n_steps=None, batchsize=100000):
         """

--- a/numcmctools/plotstack.py
+++ b/numcmctools/plotstack.py
@@ -24,7 +24,7 @@ class PlotStack:
         self.plotted_variables = []
         self.plots = []
 
-    def add_plot(self,variables, priors, constraints, bins, axrange=None, mo_option=False):
+    def add_plot(self,variables, priors, empirical_priors, bins, axrange=None, mo_option=False):
         """
         Add a plot to the stack
   
@@ -32,8 +32,8 @@ class PlotStack:
                     Only 1D and 2D are currently supported. Custom variables can
                     be declared when through the mcmcsamples class
         :priors: a list of priors in the Funtion:Variable format
-        :constraints: A list of strings with the unique names of the constraints
-                      to be applied. If None, the constraints defined in the
+        :empirical_priors: A list of strings with the unique names of the empirical priors
+                      to be applied. If None, the empirical priors defined in the
                       MCMCSamples chain will be used.
         :bins: number of bins or bin edges, formatted for either 1 or 2D as in the numpy
                documentation for histogram (https://numpy.org/doc/stable/reference/generated/numpy.histogram.html)
@@ -60,29 +60,29 @@ class PlotStack:
                     logger.debug(f"Prior for variable {var} supplied in plot: {variables}: {parsed_priors[var]}")
                     plot_jacobians[var] = self.jacobian_graph.get_jacobian_func(self.chain.variable_priors[var], parsed_priors[var])
         
-        # Add the constraints to the plotting function
-        plot_constraints = {}
+        # Add the empirical_priors to the plotting function
+        plot_empirical_priors = {}
 
-        # First check if the user supplied any constraints. If not, check if the
-        # chain has any constraints to be applied by default
-        if constraints == None:
-            constraints = []
-            for constraint in self.chain.constraints:
-                if self.chain.constraints[constraint].applied_default:
-                    constraints.append(constraint)
+        # First check if the user supplied any empirical_priors. If not, check if the
+        # chain has any empirical_priors to be applied by default
+        if empirical_priors == None:
+            empirical_priors = []
+            for empirical_prior in self.chain.empirical_priors:
+                if self.chain.empirical_priors[empirical_prior].applied_default:
+                    empirical_priors.append(empirical_prior)
 
-        for constraint in constraints:
-            if constraint not in self.chain.constraints:
-                raise TypeError(f"The constraint you supplied in plot, {constraint}, is not defined in the MCMCSamples chain")
+        for empirical_prior in empirical_priors:
+            if empirical_prior not in self.chain.empirical_priors:
+                raise TypeError(f"The empirical prior you supplied in plot, {empirical_prior}, is not defined in the MCMCSamples chain")
 
-            logger.debug(f"Constraint for variable {constraint} supplied in plot: {variables}: {self.chain.constraints[constraint]}")
-            plot_constraints[constraint] = self.chain.constraints[constraint]
+            logger.debug(f"Empirical prior for variable {empirical_prior} supplied in plot: {variables}: {self.chain.empirical_priors[empirical_prior]}")
+            plot_empirical_priors[empirical_prior] = self.chain.empirical_priors[empirical_prior]
 
-            # Make sure we add the variables needed for the constraints to the plotted variables
+            # Make sure we add the variables needed for the empirical priors to the plotted variables
             # TODO Need to consolidate this with jacobians etc...
-            for var in self.chain.constraints[constraint].variables:
+            for var in self.chain.empirical_priors[empirical_prior].variables:
                 if var not in self.chain.variables:
-                    raise TypeError(f"The variable {var} in constraint {constraint} is not defined in the MCMCSamples chain")
+                    raise TypeError(f"The variable {var} in empirical prior {empirical_prior} is not defined in the MCMCSamples chain")
                 self.plotted_variables.append(var)
 
         # Crash if user supplied a non-existant variable
@@ -96,7 +96,7 @@ class PlotStack:
                 continue
             self.plotted_variables.append(var)
 
-        self.plots.append(Plot(variables, plot_jacobians, plot_constraints, bins, axrange, mo_option))
+        self.plots.append(Plot(variables, plot_jacobians, plot_empirical_priors, bins, axrange, mo_option))
 
     def fill_plots(self,n_steps=None, batchsize=100000):
         """

--- a/numcmctools/plotstack.py
+++ b/numcmctools/plotstack.py
@@ -29,9 +29,12 @@ class PlotStack:
         Add a plot to the stack
   
         :variables: Array of strings indicating the variables to be plotted.
-                    Only 1D and 2D are currently supported. Custom variables can be declared
-                    when through the mcmcsamples class
+                    Only 1D and 2D are currently supported. Custom variables can
+                    be declared when through the mcmcsamples class
         :priors: a list of priors in the Funtion:Variable format
+        :constraints: A list of strings with the unique names of the constraints
+                      to be applied. If None, the constraints defined in the
+                      MCMCSamples chain will be used.
         :bins: number of bins or bin edges, formatted for either 1 or 2D as in the numpy
                documentation for histogram (https://numpy.org/doc/stable/reference/generated/numpy.histogram.html)
                or histogram2D (https://numpy.org/doc/stable/reference/generated/numpy.histogram2d.html)
@@ -59,6 +62,16 @@ class PlotStack:
         
         # Add the constraints to the plotting function
         plot_constraints = {}
+
+        # First check if the user supplied any constraints. If not, check if the
+        # chain has any constraints to be applied by default
+        if constraints == None:
+            constraints = []
+            for constraint in self.chain.constraints:
+                print(f"Checking constraint {constraint} in chain")
+                if self.chain.constraints[constraint].applied_default:
+                    constraints.append(constraint)
+
         for constraint in constraints:
             if constraint not in self.chain.constraints:
                 raise TypeError(f"The constraint you supplied in plot, {constraint}, is not defined in the MCMCSamples chain")

--- a/numcmctools/plotstack.py
+++ b/numcmctools/plotstack.py
@@ -66,6 +66,13 @@ class PlotStack:
             logger.debug(f"Constraint for variable {constraint} supplied in plot: {variables}: {self.chain.constraints[constraint]}")
             plot_constraints[constraint] = self.chain.constraints[constraint]
 
+            # Make sure we add the variables needed for the constraints to the plotted variables
+            # TODO Need to consolidate this with jacobians etc...
+            for var in self.chain.constraints[constraint].variables:
+                if var not in self.chain.variables:
+                    raise TypeError(f"The variable {var} in constraint {constraint} is not defined in the MCMCSamples chain")
+                self.plotted_variables.append(var)
+
         # Crash if user supplied a non-existant variable
         for var in variables:
             if var not in self.chain.variables:
@@ -102,6 +109,7 @@ class PlotStack:
                     if self.chain.variables[var].has_wrapper:
                         batch[var] = self.chain.variables[var].evaluate(batch)
                     continue
+                print(f"Evaluating variable {var} in the batch batch keys: {batch.keys()}")
                 batch[var] = self.chain.variables[var].evaluate(batch)
 
             for plot in self.plots:

--- a/numcmctools/plotstack.py
+++ b/numcmctools/plotstack.py
@@ -68,7 +68,6 @@ class PlotStack:
         if constraints == None:
             constraints = []
             for constraint in self.chain.constraints:
-                print(f"Checking constraint {constraint} in chain")
                 if self.chain.constraints[constraint].applied_default:
                     constraints.append(constraint)
 
@@ -122,7 +121,6 @@ class PlotStack:
                     if self.chain.variables[var].has_wrapper:
                         batch[var] = self.chain.variables[var].evaluate(batch)
                     continue
-                print(f"Evaluating variable {var} in the batch batch keys: {batch.keys()}")
                 batch[var] = self.chain.variables[var].evaluate(batch)
 
             for plot in self.plots:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,8 @@ dependencies = [
   "matplotlib",
   "sympy",
   "tqdm",
-  "uproot"
+  "uproot",
+  "scipy"
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy
 matplotlib
 tqdm
 sympy
+scipy


### PR DESCRIPTION
Adding a new functionality for user-provided 1D and 2D empirical priors from a root file. 
There is a lot of new code, so this PR description will have a bit more detailed breakdown on how to use this.

The external empirical prior must be in either `TGraph2D` format, where each point corresponds to some probability, or `THnD`, where each bin **center** corresponds to some probability. When providing `THnD`, NuMCMCTools takes the underflow and overflow bins into the account.

Empirical priors can be added in two ways:

## From a script

You can create an external empirical prior object from an outside file and add them to your MCMCSamples object and into each plot:

```python
  # Register together with variables already defined & named elsewhere in your code
  samples.add_empirical_prior(
    "daya_bay_2D_no",
    EmpiricalPrior(uproot.open("/path/to/file/with/constraints/DayaBay_2DConstraints.root:DB_2D_NO"), 
                       ["SinSq2Theta13", "AbsDm32"]),
    is_inverted=False,
    is_normal=True
  )

  # Register together with variable strings that will automatically generate those values
  samples.add_empirical_prior(
    "daya_bay_2D_io",
    EmpiricalPrior(uproot.open("/path/to/file/with/empirical_priors/DayaBay_2DConstraints.root:DB_2D_IO"), 
                       ["sin^2(2Theta13)", "abs(Deltam2_32)"]),
    is_inverted=True,
    is_normal=False
  )

# Apply both empirical priors
empirical_priors = ["daya_bay_2D_no", "daya_bay_2D_io"]

# Use the priors used to generate the chain
priors = []

stack = PlotStack(samples)
stack.add_plot(["DeltaCP", "SinSqTheta23"], priors, empirical_priors, [100, 100], [[0, 2*np.pi], [0.4, 0.6]])
```

## From the official data release file

The empirical priors can be added to the official data release file and applied automatically if the `empirical_priors` provided to the `add_plot` function is `None`. If the list is empty, no empirical priors will be applied. The empirical priors must be provided in the a directory object named `empirical_priors` with `TDirectoryFile` type, and each empirical prior should have a unique name. The `priors` `TList` should then contain information about that prior in a format:

1. Title: Unique name of the empirical prior, matching one in `empirical_priors` folder
2. A prefix `EmpiricalPrior` to distinguish this from standard functional priors.
3. Variables (separated with colon) the empirical prior applies to, e.g. `sin^2(2Theta13):abs(Deltam2_32)`
4. "NO", "IO" depending on whether the empirical prior applies to Normal or Inverted Mass Ordering. Leave this empty if the empirical prior applies to both.
5. 1 if the empirical prior should be applied automatically at plotting time if `empirical_priors` is set to `None` in the `add_plot` function. 0 otherwise.

Example:
Example:
1. Name: `DayaBay2D_2024_IO`, Titl`: `EmpiricalPrior:sin^2(2Theta13):abs(Deltam2_32):IO:1` for a 2D empirical prior automatically applied in the Inverted Mass Ordering
1. Name: `some_constraint_from_theory` Title: `EmpiricalPrior:sin^2(2Theta13):sin^2(Theta23):1` for a 2D empirical prior automatically applied across both mass orderings.

## Examples

The `examples/testchaindata.root` now has 2D empirical priors from Daya Bay added, and all the example scripts were updated. 


## TODOs:

There's quite a few potential TODOs to complete before making a new release, hopefully all short/easy, however. Here's what I was thinking about:

1. More documentation? Perhaps we should think about adding `docs` folder and split the readme into sections that are links to separate documents, the `README.md` is getting long and I doubt many people will read it.
2. Debugging: might be useful if the EmpiricalPrior object has a debugging plots option, that will dump 1D/2D probability & chisq maps with credible intervals & confidence levels. Users will be able to use these when creating their data releases.
3. Support for TH1D, TH2,3D, TGraph, and support for loading empirical priors from a saved numpy array object.
4. Need to really stress-test this before new release...
6. Add simple 2D Gaussian functional priors via prior functionality.
7. Most of the plots in `README.md` are now deprecated, the scripts now apply a 2D Daya Bay empirical priors by default. I wasn't sure how they are uploaded, they seem to be links to github assets but I do not know where these assets are.